### PR TITLE
show current sessions: targetstatus script

### DIFF
--- a/scripts/targetstatus
+++ b/scripts/targetstatus
@@ -67,7 +67,8 @@ class Connection(object):
 
     def indent_print(self, steps):
         if self._has_info():
-            line = "cid: " + self.cid + "  state: " + self.cstate
+            line = "address: " + str(self.address)
+            line += "\tcid: " + self.cid + "  state: " + self.cstate
             _indent_print(line, steps)
 
 


### PR DESCRIPTION
There seems to be no way to list the current active sessions, other than `cat /sys/kernel/config/target/iscsi/iqn.../tpg.../acls/iqn.../info`.

I would like to see who is actually connected to the target so I wrote a script that basically parses the mentioned configfs location for session information. It makes use of rtslib up to that point.

It lists the devices in use (short), the portals (short) and detailed information (both wwwns, tpg, lun, session+connection) for the currently open sessions.

Example:

```
Devices:
    md_block0   /dev/disk/by-id/md-name-nas:iscsi
Sessions:
    iscsi
        iqn.2003-01.org.linux-iscsi.nas.i686:sn.xxx
            tpgt_1
                iqn.2005-03.org.open-iscsi:xxx (NOT AUTHENTICATED)
                    0 /dev/disk/by-id/md-name-nas:iscsi (r)
                    alias: haljo    sid: 2  type: Normal  state: LOGGED_IN
                        address: 192.168.1.11   cid: 0  state: LOGGED_IN
                iqn.2005-03.org.open-iscsi:xxx (NOT AUTHENTICATED)
                    0 /dev/disk/by-id/md-name-nas:iscsi (r)
                    alias: nas  sid: 1  type: Normal  state: LOGGED_IN
                        address: 127.0.0.1  cid: 0  state: LOGGED_IN
Portals:
    0.0.0.0:3260    iscsi
```

This is in use in the Arch Linux Pakage _targetcli-fb_ for `/etc/rc.d/target status`, because `targetcli ls` did not give the right information (and a lot of less important information).

This is somewhat of a replacement of what _lio-utils_ does in `/etc/init.d/target status`, but _lio-utils_ gives no session information and has lots of information that I think are to detailed for a status overview.
