### PR TITLE
"Cannot find attribute: authentication" at ls command after adding a loop target

### DIFF
--- a/targetcli/ui_target.py
+++ b/targetcli/ui_target.py
@@ -406,8 +406,9 @@ class UITPG(UIRTSLibNode):
         else:
             description, status = ("disabled", False)
 
-        if int(self.rtsnode.get_attribute("authentication")):
-            description += ", auth"
+        if "authentication" in self.rtsnode.list_attributes():
+            if int(self.rtsnode.get_attribute("authentication")):
+                description += ", auth"
         return (description, status)
 
     def ui_command_enable(self):


### PR DESCRIPTION
Problem introduced in febb269d3af0b2bcf53f19a8a025a2b3df8f5cbf

To reproduce:
Create a loop target.
`ls` somewhere in the tree where the loop target would get displayed (like directly at the location where you are after creation).

UITPG is inherited by UITarget and that applies to loop targets.
Loop targets have no "authentication" attribute.

So we just check if the authentication attribute is available.
