### PR TITLE
Add feature support for emulate_model_alias

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -156,6 +156,17 @@ class UIBackstore(UINode):
         else:
             return completions
 
+    def ui_set_model_alias(self, storageobject):
+        if self.shell.prefs['export_backstore_as_model']:
+            try:
+                storageobject.set_attribute("emulate_model_alias", 1)
+            except RTSLibError, err:
+                if "Cannot find attribute" in str(err):
+                    raise RTSLibError("This version of target_core_mod does "
+                                      "not support export_backstore_as_model "
+                                      "functionality.  Model is unchanged.")
+                else:
+                    raise RTSLibError(str(err) + ".  Model is unchanged.")
 
 class UIPSCSIBackstore(UIBackstore):
     '''
@@ -182,6 +193,7 @@ class UIPSCSIBackstore(UIBackstore):
 
         so = PSCSIStorageObject(name, dev)
         ui_so = UIPSCSIStorageObject(so, self)
+        self.ui_set_model_alias(so)
         self.shell.log.info("Created pscsi storage object %s using %s"
                             % (name, dev))
         return self.new_node(ui_so)
@@ -213,10 +225,10 @@ class UIRDMCPBackstore(UIBackstore):
 
         so = RDMCPStorageObject(name, human_to_bytes(size))
         ui_so = UIRamdiskStorageObject(so, self)
+        self.ui_set_model_alias(so)
         self.shell.log.info("Created ramdisk %s with size %s."
                             % (name, size))
         return self.new_node(ui_so)
-
 
 class UIFileIOBackstore(UIBackstore):
     '''
@@ -309,10 +321,10 @@ class UIFileIOBackstore(UIBackstore):
             name, file_or_dev,
             size,
             write_back=write_back)
+        ui_so = UIFileioStorageObject(so, self)
+        self.ui_set_model_alias(so)
         self.shell.log.info("Created fileio %s with size %s"
                             % (name, size))
-        ui_so = UIFileioStorageObject(so, self)
-
         return self.new_node(ui_so)
 
 
@@ -336,6 +348,7 @@ class UIBlockBackstore(UIBackstore):
 
         so = BlockStorageObject(name, dev, readonly=readonly, write_back=write_back)
         ui_so = UIBlockStorageObject(so, self)
+        self.ui_set_model_alias(so)
         self.shell.log.info("Created block storage object %s using %s."
                             % (name, dev))
         return self.new_node(ui_so)

--- a/targetcli/ui_node.py
+++ b/targetcli/ui_node.py
@@ -28,6 +28,9 @@ class UINode(ConfigNode):
         ConfigNode.__init__(self, name, parent, shell)
         self.cfs_cwd = RTSRoot.configfs_dir
         self.define_config_group_param(
+            'global', 'export_backstore_as_model', 'bool',
+            'If true, the backstore name is used for the scsi inquiry model name.')
+        self.define_config_group_param(
             'global', 'auto_enable_tpgt', 'bool',
             'If true, automatically enables TPGTs upon creation.')
         self.define_config_group_param(


### PR DESCRIPTION
New method ui_set_model_alias in UIBackstore class is invoked in
the ui_command_create method of each subclass.  The method either
sets the attribute successfully or raises an informational error.
The storage object is created either way.

Signed-off-by: Tregaron Bayly tbayly@bluehost.com
