### PR TITLE
Problem with detecting Python3 on Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ X-Python3-Version: >= 3.1
 
 Package: targetcli-fb
 Architecture: all
-Depends: python3:any (>= 3.1), ${misc:Depends}, python3-configshell-fb, python3-rtslib-fb
+Depends: python3 (>= 3.1), ${misc:Depends}, python3-configshell-fb, python3-rtslib-fb
 Conflicts: targetcli, targetcli-frozen, lio-utils
 Description: CLI shell for the RisingTide Systems target (free branch).
  .


### PR DESCRIPTION
Installing the targetcli-fb*.deb returns that python3 must be newer then 3.1.

I have the newes Version installed (3.2.3)

```
root@debian1:# apt-get install python3 python-setuptools python3-setuptools python-pyparsing

python-setuptools is already the newest version.
python3-setuptools is already the newest version.
python-pyparsing is already the newest version.
python3 is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 30 not upgraded.
1 not fully installed or removed.

dpkg: dependency problems prevent configuration of targetcli-fb:
 targetcli-fb depends on python3:any (>= 3.1).

dpkg: error processing targetcli-fb (--configure):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 targetcli-fb
E: Sub-process /usr/bin/dpkg returned an error code (1)

root@debian1:# python -V
Python 2.7.3
root@debian1:# python3 -V
Python 3.2.3
```

hope that helps!
Cheers,
Alex
