### PR TITLE
Fix configuration tree inconsistency

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -151,7 +151,6 @@ class UIBackstore(UINode):
         child.rtsnode.delete()
         self.remove_child(child)
         self.shell.log.info("Deleted storage object %s." % name)
-        self.parent.parent.refresh()
 
     def ui_complete_delete(self, parameters, text, current_param):
         '''


### PR DESCRIPTION
Deleting a storage object refreshes the root. This causes the root
to release its references to its children and regenerate them. However if
we are cd'd to a node such as /backstores/ramdisk, then the objects
we are using are the old ones, not the new ones connected to the root node,
and creating a new storage object will update our tree but not root's
since we've become disconnected.

Fix this by no longer refreshing the root -- it should not require
refreshing anyways.

Reported-by: Eric Murphy emurphy@lessorsinc.com
Reported-by: Leeman Strout me@mooluv.com
Signed-off-by: Andy Grover agrover@redhat.com
