### PR TITLE
Create ALUA dir and def group in UI with storage object

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -265,7 +265,6 @@ class UIBackstore(UINode):
         for so in RTSRoot().storage_objects:
             if so.plugin == self.name:
                 ui_so = self.so_cls(so, self)
-                UIALUATargetPortGroups(ui_so)
 
     def summary(self):
         return ("Storage Objects: %d" % len(self._children), None)
@@ -649,6 +648,8 @@ class UIStorageObject(UIRTSLibNode):
         name = storage_object.name
         UIRTSLibNode.__init__(self, name, storage_object, parent)
         self.refresh()
+
+        UIALUATargetPortGroups(self)
 
     def ui_command_version(self):
         '''


### PR DESCRIPTION
Not sure what happened. I think I messed up in git somewhere.
Patches that I sent do not create the ALUA group dir on the
storage object when the storage object is created initially.
It only created them when you reran targetcli.

This patch creates the ALUA dir and default group when a storage
object is created and during restart of targetcli. So you can
now create more ALUA groups without having to restart targetli.