### PR TITLE
Clear backstore cache on refresh

### DIFF
--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -49,6 +49,10 @@ class UIRoot(UINode):
         '''
         self._children = set([])
 
+        # Invalidate any rtslib caches
+        if 'invalidate_caches' in dir(RTSRoot):
+            self.rtsroot.invalidate_caches()
+
         UIBackstores(self)
 
         # only show fabrics present in the system


### PR DESCRIPTION
rtslib creates a backstore cache from configfs as a global variable. 
The targetcli refresh function needs to clear out said cache, or you
end up with errors such as the following from an active shell if
you create a new backstore from a different shell.

/> refresh
Storage object fileio/test not found