### PR TITLE
Properly detect errors when writing backup files. (Closes: #80)

### DIFF
--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -72,12 +72,6 @@ class UIRoot(UINode):
         # Only save backups if saving to default location
         if savefile == default_save_file:
             backup_dir = os.path.dirname(savefile) + "/backup"
-            if not os.path.exists(backup_dir):
-                # Ignore error here, we will catch that problem later on
-                # anyway.
-                with ignored(IOError):
-                    os.makedirs(backup_dir)
-
             backup_name = "saveconfig-" + \
                 datetime.now().strftime("%Y%m%d-%H:%M:%S") + ".json"
             backupfile = backup_dir + "/" + backup_name


### PR DESCRIPTION
If the backup directory does not exist, properly detect that and show a
warning message to the user, so that they don't think that their
configuration was backed up, when it fact wasn't.

Additionally, try to automatically create the backup directory if it
does not exist.

Signed-off-by: Christian Seiler <christian@iwakd.de>