### PR TITLE
targetcli: handle tcmu dev creation errors

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -599,8 +599,12 @@ class UIUserBackedBackstore(UIBackstore):
         if not ok:
             raise ExecutionError("cfgstring invalid: %s" % errmsg)
 
-        so = UserBackedStorageObject(name, size=size, config=config, wwn=wwn,
-                                     hw_max_sectors=hw_max_sectors)
+        try:
+            so = UserBackedStorageObject(name, size=size, config=config,
+                                         wwn=wwn, hw_max_sectors=hw_max_sectors)
+        except:
+            raise ExecutionError("UserBackedStorageObject creation failed.")
+
         ui_so = UIUserBackedStorageObject(so, self)
         self.shell.log.info("Created user-backed storage object %s size %d."
                             % (name, size))


### PR DESCRIPTION
With these kernel patches:

https://www.spinics.net/lists/target-devel/msg15657.html

tcmu will be able to return errors during device addition.

This patch to targetcli catches errors from rtslib (rtslib will
catch the error and cleanup the configfs/kernel device and do a
raise) and return a error and message to the user.