### PR TITLE
skip refreshing user backed storage object when it is null

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -559,7 +559,7 @@ class UIUserBackedBackstore(UIBackstore):
     def refresh(self):
         self._children = set([])
         for so in RTSRoot().storage_objects:
-            if so.plugin == 'user':
+            if so.plugin == 'user' and so.config:
                 idx = so.config.find("/")
                 handler = so.config[:idx]
                 if handler == self.handler:


### PR DESCRIPTION
This patch skips refreshing user backed storage object, when the
object is null to avoid `no attribute` error.

Fixes https://github.com/open-iscsi/targetcli-fb/issues/92