### PR TITLE
backup: global option to tune max no. of backup conf files

### DIFF
--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -49,6 +49,7 @@ class TargetCLI(ConfigShell):
                      'auto_add_mapped_luns': True,
                      'auto_cd_after_create': False,
                      'auto_save_on_exit': True,
+                     'max_backup_files': '10',
                      'auto_add_default_portal': True,
                     }
 

--- a/targetcli/ui_node.py
+++ b/targetcli/ui_node.py
@@ -46,6 +46,9 @@ class UINode(ConfigNode):
         self.define_config_group_param(
             'global', 'auto_add_default_portal', 'bool',
             'If true, adds a portal listening on all IPs to new targets.')
+        self.define_config_group_param(
+            'global', 'max_backup_files', 'string',
+            'Max no. of configurations to be backed up in /etc/target/backup/ directory.')
 
     def assert_root(self):
         '''

--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -35,7 +35,6 @@ from .ui_target import UIFabricModule
 
 default_save_file = "/etc/target/saveconfig.json"
 universal_prefs_file = "/etc/target/targetcli.conf"
-default_kept_backups = 10
 
 class UIRoot(UINode):
     '''
@@ -99,12 +98,15 @@ class UIRoot(UINode):
 
                     if backup_error == None:
                         # Kill excess backups
+                        max_backup_files = int(self.shell.prefs['max_backup_files'])
+
                         try:
                             with open(universal_prefs_file) as prefs:
                                 backups = [line for line in prefs.read().splitlines() if re.match('^max_backup_files\s*=', line)]
-                                max_backup_files = int(backups[0].split('=')[1].strip())
+                                if max_backup_files < int(backups[0].split('=')[1].strip()):
+                                    max_backup_files = int(backups[0].split('=')[1].strip())
                         except:
-                            max_backup_files = default_kept_backups
+                            self.shell.log.debug("No universal prefs file '%s'." % universal_prefs_file)
 
                         files_to_unlink = list(reversed(backed_files_list))[max_backup_files:]
                         for f in files_to_unlink:

--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -101,18 +101,18 @@ class UIRoot(UINode):
                         # Kill excess backups
                         try:
                             with open(universal_prefs_file) as prefs:
-                                backups = [line for line in prefs.read().splitlines() if re.match('^kept_backups\s*=', line)]
-                                kept_backups = int(backups[0].split('=')[1].strip())
+                                backups = [line for line in prefs.read().splitlines() if re.match('^max_backup_files\s*=', line)]
+                                max_backup_files = int(backups[0].split('=')[1].strip())
                         except:
-                            kept_backups = default_kept_backups
+                            max_backup_files = default_kept_backups
 
-                        files_to_unlink = list(reversed(backed_files_list))[kept_backups:]
+                        files_to_unlink = list(reversed(backed_files_list))[max_backup_files:]
                         for f in files_to_unlink:
                             with ignored(IOError):
                                 os.unlink(f)
 
                         self.shell.log.info("Last %d configs saved in %s." % \
-                                            (kept_backups, backup_dir))
+                                            (max_backup_files, backup_dir))
                     else:
                         self.shell.log.warning("Could not create backup file %s: %s." % \
                                                (backupfile, backup_error))


### PR DESCRIPTION
Eg:
/> set global backup_files_limit=1000
Parameter backup_files_limit is now '1000'.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>