### PR TITLE
remove wrong exit code from targetcli --version

### DIFF
--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -64,7 +64,7 @@ def usage():
 
 def version():
     print("%s version %s" % (sys.argv[0], targetcli_version), file=err)
-    sys.exit(-1)
+    sys.exit(0)
 
 def main():
     '''


### PR DESCRIPTION
Calling targetcli --version is a good way to verify if targetcli is
present. Running the shell in mode '-e' will exit scripts even if
targetcli is available. Adjust exit code.

Signed-off-by: Olaf Hering <olaf@aepfle.de>