### PR TITLE
Split tcmu create and enable

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -35,6 +35,7 @@ from rtslib_fb import RTSRoot
 from rtslib_fb.utils import get_block_type
 
 from .ui_node import UINode, UIRTSLibNode
+from .ui_utils import command_enable
 
 alua_rw_params = ['alua_access_state', 'alua_access_status',
                   'alua_write_metadata', 'alua_access_type', 'preferred',
@@ -613,7 +614,7 @@ class UIUserBackedBackstore(UIBackstore):
             print()
 
     def ui_command_create(self, name, size, cfgstring, wwn=None,
-                          hw_max_sectors=None):
+                          hw_max_sectors=None, enable=True):
         '''
         Creates a User-backed storage object.
 
@@ -630,6 +631,7 @@ class UIUserBackedBackstore(UIBackstore):
 
         size = human_to_bytes(size)
         wwn = self.ui_eval_param(wwn, 'string', None)
+        enable = self.ui_eval_param(enable, 'bool', True)
 
         config = self.handler + "/" + cfgstring
 
@@ -639,7 +641,8 @@ class UIUserBackedBackstore(UIBackstore):
 
         try:
             so = UserBackedStorageObject(name, size=size, config=config,
-                                         wwn=wwn, hw_max_sectors=hw_max_sectors)
+                                         wwn=wwn, hw_max_sectors=hw_max_sectors,
+                                         enable=enable)
         except:
             raise ExecutionError("UserBackedStorageObject creation failed.")
 
@@ -761,3 +764,6 @@ class UIUserBackedStorageObject(UIStorageObject):
             config_str = so.config[idx+1:]
 
         return ("%s (%s) %s" % (config_str, bytes_to_human(so.size), so.status), True)
+
+    def ui_command_enable(self):
+        command_enable(self)

--- a/targetcli/ui_target.py
+++ b/targetcli/ui_target.py
@@ -32,6 +32,7 @@ from rtslib_fb import LUN, Target, TPG, StorageObjectFactory
 
 from .ui_backstore import complete_path
 from .ui_node import UINode, UIRTSLibNode
+from .ui_utils import command_enable, command_disable
 
 auth_params = ('userid', 'password', 'mutual_userid', 'mutual_password')
 discovery_params = auth_params + ("enable",)
@@ -510,37 +511,10 @@ class UITPG(UIRTSLibNode):
         setattr(self.rtsnode, "chap_" + auth_attr, value)
 
     def ui_command_enable(self):
-        '''
-        Enables the TPG.
-
-        SEE ALSO
-        ========
-        B{disable status}
-        '''
-        self.assert_root()
-        if self.rtsnode.enable:
-            self.shell.log.info("The TPGT is already enabled.")
-        else:
-            try:
-                self.rtsnode.enable = True
-                self.shell.log.info("The TPGT has been enabled.")
-            except RTSLibError:
-                raise ExecutionError("The TPGT could not be enabled.")
+        command_enable(self)
 
     def ui_command_disable(self):
-        '''
-        Disables the TPG.
-
-        SEE ALSO
-        ========
-        B{enable status}
-        '''
-        self.assert_root()
-        if self.rtsnode.enable:
-            self.rtsnode.enable = False
-            self.shell.log.info("The TPGT has been disabled.")
-        else:
-            self.shell.log.info("The TPGT is already disabled.")
+        command_disable(self)
 
 
 class UITarget(UITPG):

--- a/targetcli/ui_utils.py
+++ b/targetcli/ui_utils.py
@@ -1,0 +1,59 @@
+'''
+Provides various utility functions.
+
+This file is part of RTSLib.
+Copyright (c) 2011-2013 by Datera, Inc
+Copyright (c) 2011-2018 by Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+'''
+
+import os
+
+from rtslib_fb import RTSLibError
+from .ui_node import UIRTSLibNode
+
+def command_enable(ui_rtsnode):
+    '''
+    Enables the storage object.
+
+    SEE ALSO
+    ========
+    B{disable status}
+    '''
+    ui_rtsnode.assert_root()
+    rtsnode = ui_rtsnode.rtsnode
+    if rtsnode.enable:
+        ui_rtsnode.shell.log.info("%s is already enabled." % rtsnode.name)
+    else:
+        try:
+            ui_rtsnode.rtsnode.enable = True
+            ui_rtsnode.shell.log.info("%s has been enabled." % rtsnode.name)
+        except RTSLibError:
+            raise ExecutionError("The %s could not be enabled." % rtsnode.name)
+
+def command_disable(ui_rtsnode):
+    '''
+    Disables the storage obect
+
+    SEE ALSO
+    ========
+    B{enable status}
+    '''
+    ui_rtsnode.assert_root()
+    rtsnode = ui_rtsnode.rtsnode
+    if rtsnode.enable:
+        rtsnode.enable = False
+        ui_rtsnode.shell.log.info("The %s has been disabled." % rtsnode.name)
+    else:
+        ui_rtsnode.shell.log.info("The %s is already disabled." % rtsnode.name)


### PR DESCRIPTION
This is the targetcli changes for rtslib PR

https://github.com/open-iscsi/rtslib-fb/pull/122

There is one extra issue:

The user does not know the state of the device unless they do the enable command. Gluster devs, I am going to assume you guys can at least do:

1. Add an enabled/disabled field to the backend display. Something like

> 
>   | o- user:file ...................................... [Storage Objects: 1]
>   | | o- filetestsync ......... [/work/luns/lun0 (1.0GiB) activated enabled]
> 