### PR TITLE
Fix default max_backup_files in ui_command_saveconfig

### DIFF
--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -98,7 +98,7 @@ class UIRoot(UINode):
 
                     if backup_error == None:
                         # Kill excess backups
-                        max_backup_files = int(self.shell.prefs['max_backup_files'])
+                        max_backup_files = int(self.shell.default_prefs['max_backup_files'])
 
                         try:
                             with open(universal_prefs_file) as prefs:


### PR DESCRIPTION
When the targetcli exits, there is an error message：
Traceback (most recent call last):
  File "/usr/bin/targetcli", line 122, in <module>
    main()
  File "/usr/bin/targetcli", line 118, in main
    root_node.ui_command_saveconfig()
  File "/usr/lib/python2.7/site-packages/targetcli/ui_root.py", line 102, in ui_command_saveconfig
    max_backup_files = int(self.shell.prefs['max_backup_files'])
ValueError: invalid literal for int() with base 10: 'None'

Signed-off-by: tangwenji <tang.wenji@zte.com.cn>