### PR TITLE
Allow to customize a home directory

### DIFF
--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -20,7 +20,7 @@ under the License.
 
 from __future__ import print_function
 
-from os import getuid
+from os import getuid, getenv
 from targetcli import UIRoot
 from rtslib_fb import RTSLibError
 from configshell_fb import ConfigShell, ExecutionError
@@ -75,7 +75,7 @@ def main():
     else:
         is_root = False
 
-    shell = TargetCLI('~/.targetcli')
+    shell = TargetCLI(getenv("TARGETCLI_HOME", '~/.targetcli'))
 
     try:
         root_node = UIRoot(shell, as_root=is_root)

--- a/targetcli.8
+++ b/targetcli.8
@@ -456,6 +456,9 @@ the userid and password for full-feature phase for this ACL.
 .B /etc/target/saveconfig.json
 .br
 .B /etc/target/backup/*
+.SH ENVIRONMENT
+.SS TARGETCLI_HOME
+If set, this variable points to a directory that should be used instead of ~/.targetctl
 .SH SEE ALSO
 .BR targetctl (8),
 .BR tcmu-runner (8)


### PR DESCRIPTION
In some cases, it looks reasonable to have a separate preference file.

For example, we have a set of scripts to configure iscsi targets, and we
want to have a separate preference file for these scripts.

Signed-off-by: Andrei Vagin <avagin@openvz.org>