### PR TITLE
[targetcli] saveconfig: way for block-level save with delete command

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -284,7 +284,7 @@ class UIBackstore(UINode):
     def summary(self):
         return ("Storage Objects: %d" % len(self._children), None)
 
-    def ui_command_delete(self, name):
+    def ui_command_delete(self, name, save=None):
         '''
         Recursively deletes the storage object having the specified I{name}. If
         there are LUNs using this storage object, they will be deleted too.
@@ -301,7 +301,8 @@ class UIBackstore(UINode):
         except ValueError:
             raise ExecutionError("No storage object named %s." % name)
 
-        child.rtsnode.delete()
+        save = self.ui_eval_param(save, 'bool', False)
+        child.rtsnode.delete(save=save)
         self.remove_child(child)
         self.shell.log.info("Deleted storage object %s." % name)
 


### PR DESCRIPTION
currently, we can use block-level save feature for create command and
reconfig of different attributes, but there is no way to use block-level
feature for delete command.

This patch introduces 'save' flag (False on default), which can trigger
saveconfig internally as part of delete command.

$ targetcli /backstores/user:glfs delete test save=True
Deleted storage object test.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>