### PR TITLE
Do not remove the first digit when auto-completing the TPG tag

### DIFF
--- a/targetcli/ui_target.py
+++ b/targetcli/ui_target.py
@@ -384,7 +384,7 @@ class UIMultiTPGTarget(UIRTSLibNode):
         @rtype: list of str
         '''
         if current_param == 'tag':
-            tags = [child.name[4:] for child in self.children]
+            tags = [child.name[3:] for child in self.children]
             completions = [tag for tag in tags if tag.startswith(text)]
         else:
             completions = []


### PR DESCRIPTION
Instead of removing the first three characters of the "tpg" prefix to
get matches for the TPG tag number, the code removes four characters,
thus erasing the first digit of the TPG tag number.

This patches fixes issue 134.

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>