### PR TITLE
Fix a syntax error in some except clauses

### DIFF
--- a/daemon/targetclid
+++ b/daemon/targetclid
@@ -124,7 +124,7 @@ class TargetCLI:
         lock = struct.pack('hhllhh', fcntl.F_UNLCK, 0, 0, 0, 0, 0)
         try:
             fcntl.fcntl(self.pfd, fcntl.F_SETLK, lock)
-        except Exception, e:
+        except Exception as e:
             self.display(
                 self.render(
                     "fcntl(UNLCK) on pidfile failed: %s" %str(e),

--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -94,7 +94,7 @@ def try_op_lock(shell, lkfd):
     '''
     try:
         fcntl.flock(lkfd, fcntl.LOCK_EX)  # wait here until ongoing request is finished
-    except Exception, e:
+    except Exception as e:
         shell.con.display(
             shell.con.render_text(
                 "taking lock on lockfile failed: %s" %str(e),
@@ -107,7 +107,7 @@ def release_op_lock(shell, lkfd):
     '''
     try:
         fcntl.flock(lkfd, fcntl.LOCK_UN)  # allow other requests now
-    except Exception, e:
+    except Exception as e:
         shell.con.display(
             shell.con.render_text(
                 "unlock on lockfile failed: %s" %str(e),


### PR DESCRIPTION
"except Exception, e" triggers a syntax error on Python 3.7. The
correct syntax is "except Exception as e".

This patch fixes issue #142.