### PR TITLE
[targetcli] restoreconfig: add ability to restore/reload single target or storage_object

### DIFF
--- a/targetcli/ui_root.py
+++ b/targetcli/ui_root.py
@@ -173,7 +173,8 @@ class UIRoot(UINode):
 
         self.shell.log.info("Configuration saved to %s" % savefile)
 
-    def ui_command_restoreconfig(self, savefile=default_save_file, clear_existing=False):
+    def ui_command_restoreconfig(self, savefile=default_save_file, clear_existing=False,
+                                 target=None, storage_object=None):
         '''
         Restores configuration from a file.
         '''
@@ -185,7 +186,10 @@ class UIRoot(UINode):
             self.shell.log.info("Restore file %s not found" % savefile)
             return
 
-        errors = self.rtsroot.restore_from_file(savefile, clear_existing)
+        target = self.ui_eval_param(target, 'string', None)
+        storage_object = self.ui_eval_param(storage_object, 'string', None)
+        errors = self.rtsroot.restore_from_file(savefile, clear_existing,
+                                                target, storage_object)
 
         self.refresh()
 


### PR DESCRIPTION
Problem:
-------
Right now, if any target or storage_object is failed to load as part of
target service bringup or manual restoreconfig, may be because of an issue from
the backend, then there is no way to reload that single storage_object or target,
we need to reload/restart all the targets/storage_objects present in the node
just to load one single target/storage_object, this interrupts on going
I/O (via this path) for all the volumes hosted within the node.

Solution:
--------
Add a capability to reload single target or storage_object without touching other
targets or storage_objects hosted in the node.

usage:
```
$ targetcli
targetcli shell version 2.1.fb49
Copyright 2011-2013 by Datera, Inc and others
For help on commands, type 'help'.

/> help
[...]

AVAILABLE COMMANDS
  The following commands are available in the current path:

[...]
    - restoreconfig [savefile] [clear_existing] [target] [storage_object]
[...]
```
Ex 1. reload single storage_object
```
$ targetcli restoreconfig /etc/target/saveconfig.json clear_existing \
    storage_object=blockx
```

Ex 2. reload single target
```
$ targetcli restoreconfig /etc/target/saveconfig.json clear_existing \
    target=iqn.2016-12.org.gluster-block:xxx
```

Ex 3. reload a given target and storage_object
```
$ targetcli restoreconfig /etc/target/saveconfig.json clear_existing \
    target=iqn.2016-12.org.gluster-block:xxx storage_object=blockx
```

Depends on: https://github.com/open-iscsi/rtslib-fb/pull/152

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>