### PR TITLE
targetclid.sock: change SocketMode to 0600

### DIFF
--- a/systemd/targetclid.socket
+++ b/systemd/targetclid.socket
@@ -4,6 +4,7 @@ Documentation=man:targetclid(8)
 
 [Socket]
 ListenStream=/var/run/targetclid.sock
+SocketMode=0600
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
SocketMode=                                                            
If listening on a file system socket or FIFO, this option specifies the
file system access mode used when creating the file node. Takes an     
access mode in octal notation. Defaults to 0666.                       
                                                                       
Thanks Alex Murray[@alexmurray], for reporting.                        
                                                                       
Fixes: #162 
Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>    
