### PR TITLE
Fix targetclid daemon infinite stuck

### DIFF
--- a/daemon/targetclid
+++ b/daemon/targetclid
@@ -154,7 +154,7 @@ class TargetCLI:
                 connection.close()
                 still_listen = False
             else:
-                self.con._stdout = self.con._stderr = f = io.StringIO()
+                self.con._stdout = self.con._stderr = f = io.BytesIO()
                 try:
                     # extract multiple commands delimited with '%'
                     list_data = data.decode().split('%')


### PR DESCRIPTION
We need to open a byte IO stream because we are actually dealing with
binary data in memory.

Signed-off-by: Prasanna Kumar Kalever <prasanna.kalever@redhat.com>