### PR TITLE
daemonized-mode: add interactive shell support

### DIFF
--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -122,7 +122,7 @@ def completer(text, state):
     except IndexError:
         return None
 
-def call_daemon(shell, req):
+def call_daemon(shell, req, interactive):
     try:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     except socket.error as err:
@@ -140,9 +140,23 @@ def call_daemon(shell, req):
                 "then run '#targetcli --disable-daemon'", 'red'))
         sys.exit(1)
 
+    # Two cases where we want to get pwd:
+    # 1. Before starting shell in interactive mode, needed for setting terminal
+    # 2. And only in Interactive mode, having command 'cd'
+    get_pwd = False
+    if interactive:
+        if not req:
+            req = "pwd"
+            get_pwd = True
+        elif "cd " in req:
+            req += "%pwd"
+            get_pwd = True
+    else:
+        req = "cd /%" + req # Non-interactive modes always consider start at '/'
+
     try:
         # send request
-        sock.sendall(req)
+        sock.sendall(req.encode())
     except socket.error as err:
         shell.con.display(shell.con.render_text(err, 'red'))
         sys.exit(1)
@@ -153,14 +167,29 @@ def call_daemon(shell, req):
     amount_received = 0
 
     # get the actual data in chunks
+    output = ""
+    path = ""
     while amount_received < amount_expected:
         data = sock.recv(1024)
         data = data.decode()
         amount_received += len(data)
-        print(data, end ="")
+        output += data
+
+    if get_pwd:
+        output_split = output.splitlines()
+        lines = len(output_split)
+        for i in range(0, lines):
+            if i == lines-1:
+                path = str(output_split[i])
+            else:
+                print(str(output_split[i]), end ="\n")
+    else:
+        print(output, end ="")
 
     sock.send(b'-END@OF@DATA-')
     sock.close()
+
+    return path
 
 def switch_to_daemon(shell, interactive):
     readline.set_completer(completer)
@@ -173,7 +202,7 @@ def switch_to_daemon(shell, interactive):
 
     if len(sys.argv) > 1:
         command = " ".join(sys.argv[1:])
-        call_daemon(shell, command.encode())
+        call_daemon(shell, command, False)
         sys.exit(0)
 
     if interactive:
@@ -188,10 +217,14 @@ def switch_to_daemon(shell, interactive):
                           "type 'exit' to run them all in one go.\n"
                           % targetcli_version)
 
+    prompt_path = "/"
+    if interactive:
+        prompt_path = call_daemon(shell, None, interactive) # get the initial path
+
     inputs = []
     real_exit=False
     while True:
-        shell.con.raw_write("/> ")
+        shell.con.raw_write("%s> " %prompt_path)
         command = six.moves.input()
         if command.lower() == "exit":
             real_exit=True
@@ -201,12 +234,17 @@ def switch_to_daemon(shell, interactive):
             inputs.append(command)
             if real_exit:
                 command = '%'.join(inputs)  # delimit multiple commands with '%'
-                call_daemon(shell, command.encode())
+                call_daemon(shell, command, interactive)
                 break
         else:
             if real_exit:
                 break
-            call_daemon(shell, command.encode())
+            path = call_daemon(shell, command, interactive)
+            if path:
+                if path[0] == "/":
+                    prompt_path = path
+                else:
+                    print(path)  # Error No Path ...
 
     sys.exit(0)
 

--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -224,8 +224,7 @@ def switch_to_daemon(shell, interactive):
     inputs = []
     real_exit=False
     while True:
-        shell.con.raw_write("%s> " %prompt_path)
-        command = six.moves.input()
+        command = six.moves.input("%s> " %prompt_path)
         if command.lower() == "exit":
             real_exit=True
         elif not command:

--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -64,6 +64,7 @@ class TargetCLI(ConfigShell):
                      'max_backup_files': '10',
                      'auto_add_default_portal': True,
                      'auto_use_daemon': False,
+                     'daemon_use_batch_mode': False,
                     }
 
 def usage():
@@ -160,9 +161,8 @@ def call_daemon(shell, req):
 
     sock.send(b'-END@OF@DATA-')
     sock.close()
-    sys.exit(0)
 
-def get_arguments(shell):
+def switch_to_daemon(shell, interactive):
     readline.set_completer(completer)
     readline.set_completer_delims('')
 
@@ -173,27 +173,42 @@ def get_arguments(shell):
 
     if len(sys.argv) > 1:
         command = " ".join(sys.argv[1:])
-    else:
-        inputs = []
+        call_daemon(shell, command.encode())
+        sys.exit(0)
+
+    if interactive:
         shell.con.display("targetcli shell version %s\n"
-                        "Entering targetcli batch mode for daemonized approach.\n"
-                        "Enter multiple commands separated by newline and "
-                        "type 'exit' to run them all in one go.\n"
-                        % targetcli_version)
-        while True:
-            shell.con.raw_write("/> ")
-            command = six.moves.input()
-            if command.lower() == "exit":
-                break
+                          "Entering targetcli interactive mode for daemonized approach.\n"
+                          "Type 'exit' to quit.\n"
+                          % targetcli_version)
+    else:
+        shell.con.display("targetcli shell version %s\n"
+                          "Entering targetcli batch mode for daemonized approach.\n"
+                          "Enter multiple commands separated by newline and "
+                          "type 'exit' to run them all in one go.\n"
+                          % targetcli_version)
+
+    inputs = []
+    real_exit=False
+    while True:
+        shell.con.raw_write("/> ")
+        command = six.moves.input()
+        if command.lower() == "exit":
+            real_exit=True
+        elif not command:
+            continue
+        if not interactive:
             inputs.append(command)
-        command = '%'.join(inputs)  # delimit multiple commands with '%'
+            if real_exit:
+                command = '%'.join(inputs)  # delimit multiple commands with '%'
+                call_daemon(shell, command.encode())
+                break
+        else:
+            if real_exit:
+                break
+            call_daemon(shell, command.encode())
 
-    if not command:
-        sys.exit(1)
-
-    usage_version(command);
-
-    return command
+    sys.exit(0)
 
 def main():
     '''
@@ -225,8 +240,12 @@ def main():
         if sys.argv[1] in ("disable-daemon", "--disable-daemon"):
             disable_daemon=True
 
+    interactive_mode = True
+    if shell.prefs['daemon_use_batch_mode']:
+        interactive_mode = False
+
     if use_daemon and not disable_daemon:
-        call_daemon(shell, get_arguments(shell).encode())
+        switch_to_daemon(shell, interactive_mode)
         # does not return
 
     try:

--- a/targetcli/ui_node.py
+++ b/targetcli/ui_node.py
@@ -52,6 +52,9 @@ class UINode(ConfigNode):
         self.define_config_group_param(
             'global', 'auto_use_daemon', 'bool',
             'If true, commands will be sent to targetclid.')
+        self.define_config_group_param(
+            'global', 'daemon_use_batch_mode', 'bool',
+            'If true, use batch mode for daemonized approach.')
 
     def assert_root(self):
         '''

--- a/targetclid.8
+++ b/targetclid.8
@@ -30,11 +30,38 @@ $ targetcli set global auto_use_daemon=true
 .br
 $ targetcli ls
 .TP
-You can use batch mode for sending multiple commands in one go,
+You can use interactive mode,
 .br
 $ targetcli <hit-enter>
 .br
-targetcli shell version 2.1.50
+targetcli shell version 2.1.51
+.br
+Entering targetcli interactive mode for daemonized approach.
+.br
+Type 'exit' to quit.
+.br
+/> pwd
+.br
+/
+.br
+/> cd /iscsi
+.br
+/> pwd
+.br
+/iscsi
+.br
+/> exit
+.br
+.TP
+You can also use batch mode for sending multiple commands in one go,
+.br
+$ targetcli set global daemon_use_batch_mode=true
+.br
+Parameter daemon_use_batch_mode is now 'true'.
+.br
+$ targetcli <hit-enter>
+.br
+targetcli shell version 2.1.51
 .br
 Entering targetcli batch mode for daemonized approach.
 .br


### PR DESCRIPTION
set interactive mode as default to make it appear similar to cli approach,

```
$ targetcli
targetcli shell version 2.1.51
Entering targetcli interactive mode for daemonized approach.
Type 'exit' to quit.

/> pwd
/
/> cd /iscsi
/> pwd
/iscsi
/> exit

```

Here we introduce a new global varibale `daemon_use_batch_mode` for switching betwe
batch and interactive modes.

```
$ targetcli set global daemon_use_batch_mode=true
Parameter daemon_use_batch_mode is now 'true'.

$ targetcli
targetcli shell version 2.1.51
Entering targetcli batch mode for daemonized approach.
Enter multiple commands separated by newline and type 'exit' to run them
all in one go.

/> pwd
/> cd /iscsi
/> pwd
/
/iscsi

```

Fixes: #160
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>
