### PR TITLE
refresh on delete backstore

### DIFF
--- a/targetcli/ui_backstore.py
+++ b/targetcli/ui_backstore.py
@@ -302,12 +302,13 @@ class UIBackstore(UINode):
             raise ExecutionError("No storage object named %s." % name)
 
         save = self.ui_eval_param(save, 'bool', False)
+        rn = self.get_root()
         if save:
-            rn = self.get_root()
             rn._save_backups(default_save_file)
 
         child.rtsnode.delete(save=save)
         self.remove_child(child)
+        rn.ui_command_refresh()
         self.shell.log.info("Deleted storage object %s." % name)
 
     def ui_complete_delete(self, parameters, text, current_param):


### PR DESCRIPTION
Problem:
-------
```
[root@server1 ~]# targetcli                                                                                                                                                                                                          
targetcli shell version 2.1.51
Copyright 2011-2013 by Datera, Inc and others.
For help on commands, type 'help'.

/>  backstores/fileio create name=disk file_or_dev=/tmp/iscsidisk size=1G
/tmp/iscsidisk exists, using its size (1073741824 bytes) instead
Created fileio disk with size 1073741824
/> iscsi/ create
Created target iqn.2003-01.org.linux-iscsi.server1.x8664:sn.5679adc37869.
Created TPG 1.
/> iscsi/iqn.2003-01.org.linux-iscsi.server1.x8664:sn.5679adc37869/tpg1/luns create /backstores/fileio/disk
Created LUN 0.
/> ls
o- / .............................................................. [...]
  o- backstores ................................................... [...]
  | o- block ...................................................... [Storage Objects: 0]
  | o- fileio ..................................................... [Storage Objects: 1]
  | | o- disk ..................................................... [/tmp/iscsidisk (1.0GiB) write-back activated]
  | |   o- alua ................................................... [ALUA Groups: 1]
  | |     o- default_tg_pt_gp ..................................... [ALUA state: Active/optimized]
  | o- pscsi ...................................................... [Storage Objects: 0]
  | o- ramdisk .................................................... [Storage Objects: 0]
  | o- user:glfs .................................................. [Storage Objects: 0]
  o- iscsi ........................................................ [Targets: 1]
  | o- iqn.2003-01.org.linux-iscsi.server1.x8664:sn.5679adc37869 .. [TPGs: 1]
  |   o- tpg1 ..................................................... [disabled]
  |     o- acls ................................................... [ACLs: 0]
  |     o- luns ................................................... [LUNs: 1]
  |     | o- lun0 ................................................. [fileio/disk (/tmp/iscsidisk) (default_tg_pt_gp)]
  |     o- portals ................................................ [Portals: 0]
  o- loopback ..................................................... [Targets: 0]
  o- vhost ........................................................ [Targets: 0]
  o- xen-pvscsi ................................................... [Targets: 0]
/> backstores/fileio/ delete disk
Deleted storage object disk.
/> ls
This LUN does not exist in configFS
/>

```

Fix:
---
Refresh at the end of ui_command_delete()

Credits to:
* Jing Yan [jiyan@redhat.com] who initially reported this issue.
* Matt Coleman [@iammattcoleman] for bringing attention on this issue.
* Maurizio Lombardi [@maurizio-lombardi] for reproducer.

Fixes: BZ#1571728
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>