### PR TITLE
Do not install systemd files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
                'scripts/targetcli',
                'daemon/targetclid'
               ],
-    data_files = [('/lib/systemd/system', ['systemd/targetclid.socket', 'systemd/targetclid.service'])],
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
setuptools should not perform OS-specific actions such as installing systemd units.
OS-specific actions should be handled by the package manager.