### PR TITLE
Add workflows for pre-commit and PyPI release

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+on:
+  release:
+    types:
+      - published
+
+name: pypi-release
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/targetcli
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,4 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Contribute
 ----------
 targetcli complies with PEP 621 and as such can be built and installed with tools like `build` and `pip`.
 
-For development, consider using [Hatch](https://hatch.pypa.io):
-`hatch shell` to create and enter a Python virtualenv with the project installed in editable mode
-`pre-commit install` to enable pre-commit hooks
-`hatch build` to create tarball and wheel
+For development, consider using [Hatch](https://hatch.pypa.io):  
+`hatch shell` to create and enter a Python virtualenv with the project installed in editable mode  
+`pre-commit install` to enable pre-commit hooks  
+`hatch build` to create tarball and wheel  
 
 "fb" -- "free branch"
 ---------------------

--- a/src/targetcli/targetcli_shell.py
+++ b/src/targetcli/targetcli_shell.py
@@ -308,11 +308,11 @@ def main():
     if not is_root:
         shell.con.display("You are not root, disabling privileged commands.\n")
 
-    try:
-        while not shell._exit:
+    while not shell._exit:
+        try:
             shell.run_interactive()
-    except (RTSLibError, ExecutionError) as msg:
-        shell.log.error(str(msg))
+        except (RTSLibError, ExecutionError) as msg:  # noqa: PERF203 - would otherwise exit shell
+            shell.log.error(str(msg))
 
     if shell.prefs['auto_save_on_exit'] and is_root:
         shell.log.info("Global pref auto_save_on_exit=true")


### PR DESCRIPTION
The simple linting step uses the existing pre-commit config and https://github.com/pre-commit/action. The action could be replaced with https://pre-commit.ci/, as needed.

Release step uses the reference setup from https://docs.pypi.org/trusted-publishers/.
It would be trigger once release is created here on github.