### PR TITLE
Improve the handling of stdout and stderr in daemon mode

### DIFF
--- a/src/targetcli/targetcli_shell.py
+++ b/src/targetcli/targetcli_shell.py
@@ -168,25 +168,57 @@ def call_daemon(shell, req, interactive):
     # get the actual data in chunks
     output = ""
     path = ""
+    raise_error = False
     while amount_received < amount_expected:
         data = sock.recv(1024)
         data = data.decode()
         amount_received += len(data)
         output += data
 
-    if get_pwd:
-        output_split = output.splitlines()
-        lines = len(output_split)
-        for i in range(lines):
-            if i == lines - 1:
-                path = str(output_split[i])
+    # Check if output is in new format (STDOUT/STDERR)
+    if "STDOUT:" in output and "STDERR:" in output:
+        parts = output.split("STDERR:")
+        if len(parts) == 2:
+            stdout_part = parts[0].split("STDOUT:")[1].strip()
+            stderr_content = parts[1].strip()
+            stdout_content = stdout_part
+
+            if get_pwd:
+                output_split = stdout_content.splitlines()
+                lines = len(output_split)
+                for i in range(0, lines):
+                    if i == lines-1:
+                        path = str(output_split[i])
+                    else:
+                        print(str(output_split[i]), end="\n")
+
             else:
-                print(str(output_split[i]), end="\n")
+                # Print stdout content
+                if stdout_content:
+                    print(stdout_content, end="\n")
+                # Print stderr content
+                if stderr_content:
+                    print(stderr_content, end="\n", file=sys.stderr)
+                    raise_error = True
+
     else:
-        print(output, end="")
+        # Handle old format (plain text)
+        if get_pwd:
+            output_split = output.splitlines()
+            lines = len(output_split)
+            for i in range(0, lines):
+                if i == lines-1:
+                    path = str(output_split[i])
+                else:
+                    print(str(output_split[i]), end="\n")
+        else:
+            print(output, end="")
 
     sock.send(b'-END@OF@DATA-')
     sock.close()
+
+    if raise_error and not interactive:
+        sys.exit(1)
 
     return path
 

--- a/src/targetcli/targetclid.py
+++ b/src/targetcli/targetclid.py
@@ -153,28 +153,51 @@ class TargetCLI:
                 connection.close()
                 still_listen = False
             else:
-                self.con._stdout = self.con._stderr = f = tempfile.NamedTemporaryFile(mode='w', delete=False)
+                # Create separate tempfiles for stdout and stderr
+                stdout_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+                stderr_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+
+                # Save original stdout/stderr
+                orig_stdout = self.con._stdout
+                orig_stderr = self.con._stderr
+
+                # Redirect to tempfiles
+                self.con._stdout = stdout_file
+                self.con._stderr = stderr_file
+
                 try:
                     # extract multiple commands delimited with '%'
                     list_data = data.decode().split('%')
                     for cmd in list_data:
                         self.shell.run_cmdline(cmd)
                 except Exception as e:
-                    print(str(e), file=f)  # push error to stream
+                    print(str(e), file=stderr_file)
+                # Restore original stdout/stderr
+                self.con._stdout = orig_stdout
+                self.con._stderr = orig_stderr
 
-                # Restore
-                self.con._stdout = self.con_stdout_
-                self.con._stderr = self.con_stderr_
-                f.close()
+                # Close tempfiles
+                stdout_file.close()
+                stderr_file.close()
 
-                with open(f.name) as f:
-                    output = f.read()
-                    var = struct.pack('i', len(output))
-                    connection.sendall(var)  # length of string
-                    if len(output):
-                        connection.sendall(output.encode())  # actual string
+                # Read contents
+                with open(stdout_file.name, 'r') as f:
+                    stdout_content = f.read()
+                with open(stderr_file.name, 'r') as f:
+                    stderr_content = f.read()
 
-                Path(f.name).unlink()
+                # Create combined output
+                combined_output = f"STDOUT: {stdout_content}\nSTDERR: {stderr_content}"
+
+                # Send combined output
+                var = struct.pack('i', len(combined_output))
+                connection.sendall(var)  # length of string
+                if len(combined_output):
+                    connection.sendall(combined_output.encode())  # actual string
+
+                # Cleanup tempfiles
+                Path(stdout_file.name).unlink()
+                Path(stderr_file.name).unlink()
 
 
 def usage():


### PR DESCRIPTION
In daemon mode, the STDOUT and STDERR messages were aggregated into a single text file which was then relayed back to the caller. There was no differentiation between the STDOUT and STDERR which caused it to return 0 and not log any STDERR even in command failure case. Following is an example:

$ targetcli get global auto_use_daemon
auto_use_daemon=true

$ targetcli err; echo $?
Command not found err
0

The fix is to create separate temp files for stdout and stderr.

After the fix it returns error correctly (1):

$ targetcli get global auto_use_daemon
auto_use_daemon=true

$ targetcli err; echo $?
Command not found err
1