### PR TITLE
Fix global parameters not persisted when set

### DIFF
--- a/src/targetcli/ui_node.py
+++ b/src/targetcli/ui_node.py
@@ -105,6 +105,7 @@ class UINode(ConfigNode):
 
     def ui_setgroup_global(self, parameter, value):
         ConfigNode.ui_setgroup_global(self, parameter, value)
+        self.shell.prefs.save()
         self.get_root().refresh()
 
     def ui_type_yesno(self, value=None, enum=False, reverse=False):


### PR DESCRIPTION
Call prefs.save() from ui_setgroup_global() so that "set global ..." writes updated values to the preferences file. Without this, the change only applied in memory and was lost when the process exited, so a subsequent "get global ..." (e.g. auto_use_daemon) still showed the old value.